### PR TITLE
changing entry_points for main:cli since main:main requires config_path

### DIFF
--- a/pyvideosync/main.py
+++ b/pyvideosync/main.py
@@ -215,8 +215,7 @@ def main(config_path):
 
         logger.info(f"Saved {camera_serial} to {video_output_path}")
 
-
-if __name__ == "__main__":
+def cli():
     parser = argparse.ArgumentParser(
         description="Video synchronization tool for neural data and camera recordings."
     )
@@ -230,3 +229,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     main(args.config)
+
+if __name__ == "__main__":
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "stitch-videos=pyvideosync.main:main",
+            "stitch-videos=pyvideosync.main:cli",
             "plot-nev-cam-exposure=profiler.plot_nev_cam_exposure:main",
             "profile-cam-json=profiler.profile_camera_jsons:main",
             "benchmark-nevs=profiler.benchmark_nevs:main",


### PR DESCRIPTION
the `main()` function used to have no arguments but now requires config_path, so this is just creating a `cli()` entry point that does not require any arguments
